### PR TITLE
fix: Patch to make MeowPDF functional and buildable on MacOS devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,14 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
@@ -219,12 +217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,18 +235,6 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -331,27 +311,28 @@ dependencies = [
 
 [[package]]
 name = "mupdf"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e286545311485e9468840b81b9014f4164ab16b071a53fa755536d52f43b915"
+checksum = "3a6499267155b9ae03ff8e53c456d0bfff988b2647d62ff1df038f39ebe93a0c"
 dependencies = [
  "bitflags 2.6.0",
  "mupdf-sys",
  "num_enum",
  "once_cell",
- "serde",
- "serde_json",
+ "zerocopy",
 ]
 
 [[package]]
 name = "mupdf-sys"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2bd5de0f9c7ab0da37de2299626b8449a1263304f8a54def2a93ddfe31ee9b"
+checksum = "13e9a0d4e844ab50315d43312f3d62f72c77205b07c8ee21cbd4b52bdc2a9910"
 dependencies = [
  "bindgen",
  "cc",
  "pkg-config",
+ "regex",
+ "zerocopy",
 ]
 
 [[package]]
@@ -483,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -495,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -506,21 +487,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "same-file"
@@ -549,18 +524,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -846,4 +809,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +385,7 @@ dependencies = [
  "bitflags 2.6.0",
  "crossbeam-channel",
  "filetime",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ version = "0.1.0"
 base64 = "0.22.1"
 dirs = "5.0.1"
 mupdf = { default-features = false, version = "0.4.4" }
-notify = { features = ["crossbeam-channel"], default-features = false, version = "6.1.1" }
+notify = { version = "6.1.1" }
 regex-automata = { features = ["unicode", "syntax", "dfa", "meta"], default-features = false, version = "0.4.7" }
-serde = { default-features = false, version = "1.0.204" }
+serde = { version = "1.0.204" }
 toml = { features = ["parse"], default-features = false, version = "0.8.15" }
 
 [dependencies.crossbeam-channel]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ version = "0.1.0"
 [dependencies]
 base64 = "0.22.1"
 dirs = "5.0.1"
-mupdf = { default-features = false, version = "0.4.4" }
+mupdf = { default-features = false, version = "0.5" }
 notify = { version = "6.1.1" }
 regex-automata = { features = ["unicode", "syntax", "dfa", "meta"], default-features = false, version = "0.4.7" }
-serde = { version = "1.0.204" }
+serde = { version = "1.0.204", features=["derive"] }
 toml = { features = ["parse"], default-features = false, version = "0.8.15" }
 
 [dependencies.crossbeam-channel]

--- a/src/drivers/tui.rs
+++ b/src/drivers/tui.rs
@@ -88,7 +88,7 @@ mod ioctl {
     /* Big thanks to
      * https://github.com/nix-rust/nix/issues/201#issuecomment-154902042 */
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-    const TIOCGWINSZ: libc::c_ulong = 0x40087468;
+    const TIOCGWINSZ: u64 = 0x40087468;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     const TIOCGWINSZ: u64 = 0x5413;
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -248,7 +248,7 @@ impl Viewer {
             let config: &Config = CONFIG.get().unwrap();
             let mut document: Document;
             let mut cache: Vec<Page> = Vec::new();
-            let mut alpha: f32 = 0.0f32;
+            let mut alpha: bool = false;
             let mut inverse: bool = false;
 
             let mut alpha_run: SystemTime = SystemTime::now();
@@ -337,7 +337,7 @@ impl Viewer {
                             continue;
                         }
 
-                        alpha = !(alpha != 0.0) as u32 as f32;
+                        alpha = !alpha;
                         clear_channel!(receive_display);
                         let _ = informer_broadcast.send(());
                     },


### PR DESCRIPTION
**What has been done?**
1. `libc::c_ulong` has been replaced with `u64` since `libc` is not used and `u64` is the alias of `libc::c_ulong`.
2. `mupdf-rs` was upgraded from `v0.4.4` to `v0.5.0` that uses a newer version of `mupdf` which is buildable on newer MacOS devices.
3. The updates on the API of `mupdf-rs` was integrated into the project.  

**Corresponding issue**
- #1